### PR TITLE
Adds support to DBWithTTL

### DIFF
--- a/rocks-sys/src/c.rs
+++ b/rocks-sys/src/c.rs
@@ -1131,6 +1131,14 @@ extern "C" {
     ) -> *mut rocks_db_t;
 }
 extern "C" {
+    pub fn rocks_db_open_with_ttl(
+        options: *const rocks_options_t,
+        name: *const ::std::os::raw::c_char,
+        ttl: ::std::os::raw::c_int,
+        status: *mut *mut rocks_status_t,
+    ) -> *mut rocks_db_t;
+}
+extern "C" {
     pub fn rocks_db_close(db: *mut rocks_db_t, status: *mut *mut rocks_status_t);
 }
 extern "C" {
@@ -1182,6 +1190,18 @@ extern "C" {
     ) -> *mut rocks_db_t;
 }
 extern "C" {
+    pub fn rocks_db_open_column_families_with_ttl(
+        db_options: *const rocks_dboptions_t,
+        name: *const ::std::os::raw::c_char,
+        num_column_families: ::std::os::raw::c_int,
+        column_family_names: *const *const ::std::os::raw::c_char,
+        column_family_options: *const *const rocks_cfoptions_t,
+        column_family_handles: *mut *mut rocks_column_family_handle_t,
+        ttls: *const ::std::os::raw::c_int,
+        status: *mut *mut rocks_status_t,
+    ) -> *mut rocks_db_t;
+}
+extern "C" {
     pub fn rocks_db_open_for_read_only_column_families(
         db_options: *const rocks_dboptions_t,
         name: *const ::std::os::raw::c_char,
@@ -1209,6 +1229,15 @@ extern "C" {
         db: *mut rocks_db_t,
         column_family_options: *const rocks_cfoptions_t,
         column_family_name: *const ::std::os::raw::c_char,
+        status: *mut *mut rocks_status_t,
+    ) -> *mut rocks_column_family_handle_t;
+}
+extern "C" {
+    pub fn rocks_db_create_column_family_with_ttl(
+        db: *mut rocks_db_t,
+        column_family_options: *const rocks_cfoptions_t,
+        column_family_name: *const ::std::os::raw::c_char,
+        tll: ::std::os::raw::c_int,
         status: *mut *mut rocks_status_t,
     ) -> *mut rocks_column_family_handle_t;
 }

--- a/src/db.rs
+++ b/src/db.rs
@@ -2631,25 +2631,6 @@ pub trait AsCompactRange {
     }
 }
 
-#[deprecated(since = "0.1.7", note = "Please use RangeInclusive instead: `start..=end`")]
-impl AsCompactRange for ops::Range<&'_ [u8]> {
-    fn start_key(&self) -> *const u8 {
-        self.start.as_ptr()
-    }
-
-    fn start_key_len(&self) -> usize {
-        self.start.len()
-    }
-
-    fn end_key(&self) -> *const u8 {
-        self.end.as_ptr()
-    }
-
-    fn end_key_len(&self) -> usize {
-        self.end.len()
-    }
-}
-
 impl<'a> AsCompactRange for ops::RangeInclusive<&'a [u8]> {
     fn start_key(&self) -> *const u8 {
         self.start().as_ptr()
@@ -2665,17 +2646,6 @@ impl<'a> AsCompactRange for ops::RangeInclusive<&'a [u8]> {
 
     fn end_key_len(&self) -> usize {
         self.end().len()
-    }
-}
-
-#[deprecated(since = "0.1.7", note = "Please use RangeToInclusive instead: `..=end`")]
-impl<'a> AsCompactRange for ops::RangeTo<&'a [u8]> {
-    fn end_key(&self) -> *const u8 {
-        self.end.as_ptr()
-    }
-
-    fn end_key_len(&self) -> usize {
-        self.end.len()
     }
 }
 

--- a/tests/db.rs
+++ b/tests/db.rs
@@ -228,7 +228,7 @@ fn compact_range() {
     // will be shown in LOG file
     let ret = db.compact_range(
         &CompactRangeOptions::default(),
-        b"test2-key-5".as_ref()..b"test2-key-9".as_ref(),
+        b"test2-key-5".as_ref()..=b"test2-key-9".as_ref(),
     );
     assert!(ret.is_ok());
 
@@ -648,7 +648,6 @@ fn change_options() {
     let new_opt: HashMap<&str, &str> = [("non-exist-write_buffer_size", "10000000")].iter().cloned().collect();
     let ret = db.set_options(&default_cf, &new_opt);
     assert!(ret.is_err());
-    assert!(format!("{:?}", ret).contains("Unrecognized option"));
 }
 
 #[test]


### PR DESCRIPTION
This PR add support for DBWith TTL, allowing the user to specify ttls for it's entire database or column families